### PR TITLE
Add support for js-yaml dump options in serialize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ console.log(isValid); // true or false
 ### `parse(text: string): { data: object, content: string }`
 Parses YAML front matter from a given text input.
 
-### `serialize(data: object, content: string): string`
-Serializes an object and content into a YAML front matter formatted string.
+### `serialize(data: object, content: string, options?: object): string`
+Serializes an object and content into a YAML front matter formatted string. The `options` parameter accepts [js-yaml dump options](https://github.com/nodeca/js-yaml#dump-object---options-) for customizing the YAML output.
 
 ### `validate(text: string): boolean`
 Checks if a given text has valid YAML front matter.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import type { DumpOptions } from "js-yaml";
+
 declare module "matter-yaml" {
     /**
      * Parses YAML front matter and returns the structured data and content.
@@ -10,9 +12,10 @@ declare module "matter-yaml" {
      * Serializes an object and content into a front matter formatted string.
      * @param data - The front matter data object.
      * @param content - The raw content as a string.
+     * @param options - Optional YAML dump configuration options.
      * @returns A formatted front matter string.
      */
-    export function serialize(data: Record<string, any>, content: string): string;
+    export function serialize(data: Record<string, any>, content: string, options?: DumpOptions): string;
 
     /**
      * Validates whether the given text has a valid YAML front matter structure.

--- a/src/matter-yaml.js
+++ b/src/matter-yaml.js
@@ -30,10 +30,11 @@ export function parse(text) {
  * Serializes data and content into a combined string.
  * @param {object} data - An object representing the front matter (YAML).
  * @param {string} content - The main content as a string.
+ * @param options - Optional YAML dump configuration options.
  * @returns {string} - The serialized front matter and content.
  * @throws {Error} - If the data is not an object or the content is not a string.
  */
-export function serialize(data, content) {
+export function serialize(data, content, options = {}) {
     if (typeof data !== 'object' || data === null) {
         throw new TypeError(`serialize expected an object, but received ${typeof data}.`);
     }
@@ -41,7 +42,7 @@ export function serialize(data, content) {
         throw new TypeError(`serialize expected a string, but received ${typeof content}.`);
     }
 
-    const frontMatter = yaml.dump(data).trim();
+    const frontMatter = yaml.dump(data, options).trim();
     return `---\n${frontMatter}\n---\n${content}`;
 }
 


### PR DESCRIPTION
Hi there! The text on this PR is generated by AI. (IMHO) a one liner should be enough for just a couple worlds really added to the code, the rest is AI-generated documentation.

# Add support for js-yaml dump options in serialize method

## Problem
When serializing YAML front matter containing URLs (both as keys and values) along with arbitrary text, the default YAML output can be hard to read since special characters and strings aren't quoted by default.

## Solution
Added an optional `options` parameter to the `serialize` function that passes through to js-yaml's `dump` method, allowing fine-grained control over the YAML output format.

Example usage:
```js
const data = {
  'https://example.com': 'https://another-url.com',
  'description': 'Some content with: special characters'
};

// Before (hard to read):
serialize(data, content);
/*
https://example.com: https://another-url.com
description: Some content with: special characters
*/

// After (with options):
serialize(data, content, { forceQuotes: true });
/*
"https://example.com": "https://another-url.com"
"description": "Some content with: special characters"
*/
```
---

## **Implementation**
- Added optional options parameter of type DumpOptions from js-yaml
- Updated TypeScript definitions and documentation
- Maintains backward compatibility with existing usage